### PR TITLE
[pom update] update H2 database version to 2.0.206

### DIFF
--- a/gateway-portal/pom.xml
+++ b/gateway-portal/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.195</version>
+            <version>2.0.206</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Description
update H2 database version to 2.0.206 for repairing the bug which allows loading of custom classes from remote servers through JNDI. More detals to see: [https://github.com/advisories/GHSA-h376-j262-vhq6](url)

Affects
only for updating H2 maven dependency, with no impact on functionality or testing.

[x] Configuration Infrastructure
[] Docs
[] Installation
[] Performance and Scalability
[] Test and Release
[] User Experience